### PR TITLE
Jquery ajax jqxhr

### DIFF
--- a/lib/proto/ewd-client.js
+++ b/lib/proto/ewd-client.js
@@ -34,6 +34,7 @@ var EWD;
 
 (function() {
   var events = {};
+	var _io;
 
   var emitter = {
     on: function(type, callback, deleteWhenFinished) {
@@ -85,6 +86,7 @@ var EWD;
       appName = application.application;
       cookieName = application.cookieName;
     }
+		_io = io || undefined;
 
     function getCookie(name) {
       var value = "; " + document.cookie;
@@ -335,6 +337,11 @@ var EWD;
   proto.off = emitter.off;
   proto.emit = emitter.emit;
   proto.start = start;
+	Object.defineProperty(proto, 'connected', {
+		get: function() {
+			return _io ? _io.connected : undefined;
+		}
+	});
 
   EWD = new ewd();
 })();

--- a/lib/proto/ewd-client.js
+++ b/lib/proto/ewd-client.js
@@ -34,7 +34,6 @@ var EWD;
 
 (function() {
   var events = {};
-	var _io;
 
   var emitter = {
     on: function(type, callback, deleteWhenFinished) {
@@ -86,7 +85,6 @@ var EWD;
       appName = application.application;
       cookieName = application.cookieName;
     }
-		_io = io || undefined;
 
     function getCookie(name) {
       var value = "; " + document.cookie;
@@ -337,11 +335,6 @@ var EWD;
   proto.off = emitter.off;
   proto.emit = emitter.emit;
   proto.start = start;
-	Object.defineProperty(proto, 'connected', {
-		get: function() {
-			return _io ? _io.connected : undefined;
-		}
-	});
 
   EWD = new ewd();
 })();

--- a/lib/proto/ewd-client.js
+++ b/lib/proto/ewd-client.js
@@ -176,11 +176,11 @@ var EWD;
           }
           if (token || messageObj.type === 'ewd-register') {
             messageObj.token = token;
-            console.log('Ajax send: ' + JSON.stringify(messageObj));
+            if (EWD.log) console.log('Ajax send: ' + JSON.stringify(messageObj));
             (function(type) {
 
               function success(data) {
-                console.log('Ajax response for type ' + type + ': ' + JSON.stringify(data));
+                if (EWD.log) console.log('Ajax response for type ' + type + ': ' + JSON.stringify(data));
                 if (data.ewd_response !== false) {
                   handleResponse({
                     type: type,
@@ -223,8 +223,9 @@ var EWD;
                 .done(function(data) {
                   success(data);
                 })
-                .error(function(err) {
-                  var error = err.responseJSON.error;
+                .fail(function(jqXHR, textStatus, errorThrown) {
+                  var error = jqXHR.responseJSON ? jqXHR.responseJSON.error : '';
+                  if (!error) error = 'Ajax call failed: ' + textStatus;
                   fail(error);
                 });
               }

--- a/lib/proto/ewd-client.js
+++ b/lib/proto/ewd-client.js
@@ -34,6 +34,7 @@ var EWD;
 
 (function() {
   var events = {};
+  var _socket;
 
   var emitter = {
     on: function(type, callback, deleteWhenFinished) {
@@ -275,6 +276,7 @@ var EWD;
         else {
           socket = io.connect();
         }
+        _socket = socket;
         socket.on('connect', function() {
 
           EWD.disconnectSocket = function() {
@@ -335,6 +337,11 @@ var EWD;
   proto.off = emitter.off;
   proto.emit = emitter.emit;
   proto.start = start;
+  Object.defineProperty(proto, 'socketConnected', {
+    get: function() {
+      return _socket ? _socket.connected : undefined;
+    }
+  });
 
   EWD = new ewd();
 })();


### PR DESCRIPTION
removed $.ajax().error() in favour of $.ajax().fail() (works from jQuery 1.5 onwards, .error()
was removed starting from jQuery 3.0+)