### PR TITLE
Added `connect_error` event.

### DIFF
--- a/lib/proto/ewd-client.js
+++ b/lib/proto/ewd-client.js
@@ -333,6 +333,11 @@ var EWD;
           console.log('*** server has disconnected socket, possibly because it shut down or because token has expired');
           EWD.emit('socketDisconnected');
         });
+       
+        socket.on('connect_error', function() {
+          console.log('*** server cannot create a socket, possibly because it shut down');
+          EWD.emit('connect_error');
+        });
 
       }
       else {


### PR DESCRIPTION
This event is raised by socket.io in the event of the websocket-server not being available and throwing an ERR_CONNECTION_REFUSED error. This is distinct and different from the `disconnect` event which ewd-client already caters for.