### PR TITLE
Added a `has` method to check event registration

### DIFF
--- a/lib/proto/ewd-client.js
+++ b/lib/proto/ewd-client.js
@@ -69,6 +69,10 @@ var EWD;
         e.callback(data);
         if (e.deleteWhenFinished && data.finished) ev.splice(i,1);
       }
+    },
+    has: function(type) {
+      if (events[type] === undefined) { return false }
+      return events[type].length
     }
   };
 
@@ -359,6 +363,7 @@ var EWD;
   proto.on = emitter.on;
   proto.off = emitter.off;
   proto.emit = emitter.emit;
+  proto.has = emitter.has;
   proto.start = start;
 
   EWD = new ewd();


### PR DESCRIPTION
This is useful in frameworks like Vue for checking whether the events have been registered yet during route guards (for example) on a page refresh or a route call.