### PR TITLE
Add 'path' to setCookie

### DIFF
--- a/lib/proto/ewd-client.js
+++ b/lib/proto/ewd-client.js
@@ -69,6 +69,10 @@ var EWD;
         e.callback(data);
         if (e.deleteWhenFinished && data.finished) ev.splice(i,1);
       }
+    },
+    has: function(type) {
+      if (events[type] === undefined) { return false }
+      return events[type].length
     }
   };
 
@@ -359,6 +363,7 @@ var EWD;
   proto.on = emitter.on;
   proto.off = emitter.off;
   proto.emit = emitter.emit;
+  proto.has = emitter.has;
   proto.start = start;
 
   EWD = new ewd();

--- a/lib/proto/ewd-client.js
+++ b/lib/proto/ewd-client.js
@@ -333,6 +333,11 @@ var EWD;
           console.log('*** server has disconnected socket, possibly because it shut down or because token has expired');
           EWD.emit('socketDisconnected');
         });
+       
+        socket.on('connect_error', function() {
+          console.log('*** server cannot create a socket, possibly because it shut down');
+          EWD.emit('connect_error');
+        });
 
       }
       else {

--- a/lib/proto/ewd-client.js
+++ b/lib/proto/ewd-client.js
@@ -151,9 +151,10 @@ var EWD;
         if (messageObj.type === 'ewd-register') {
           token = messageObj.message.token;
 
-          EWD.setCookie = function(name) {
+          EWD.setCookie = function(name, path) {
             name = name || 'ewd-token';
-            document.cookie = name + "=" + token;
+            path = path || '/';
+            document.cookie = name + "=" + token + "; path="+path+";";
           };
 
           if (!EWD.jwt) {


### PR DESCRIPTION
When a user of an SPA hits page refresh or uses a bookmark as an entry
point into the app, it is necessary to call the EWD.setCookie function
in order to re-register the session and to map the session cookie to
the new web socket.

If the href has a different path to that when the token was first
generated, you can end up in a situation where QEWD loses track of the
session because it is seen as a new token.

This modification allows one to prevent this undesirable behaviour by
providing the ability to specify the cookie’s path and providing a
sensible default for an SPA